### PR TITLE
Fixed issue with latest Spigot versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.inventivetalent</groupId>
             <artifactId>reflectionhelper</artifactId>
-            <version>[1.7.1,)</version>
+            <version>LATEST</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Refer to https://twitter.com/FrozenDroid/status/894994757965025282.
ParticleAPI was not pulling in the latest ReflectionHelper, therefore did not know what to do with the newest Spigot version.
This was tested on the latest build of Spigot, `git-Spigot-5340a52-27b8bf9`.